### PR TITLE
Fix/deploy contracts section

### DIFF
--- a/docs/developing/deploy_facilities/using_foundry.md
+++ b/docs/developing/deploy_facilities/using_foundry.md
@@ -1,0 +1,120 @@
+---
+title: Deploy with Foundry
+proofedDate: na
+iterationBy: na
+includedInSite: true
+approvedBy: na
+comment: 
+---
+
+*This page outlines the steps for deploying and testing contracts in the Neon EVM using the Foundry tool.*
+
+## How to Use Foundry: A Tutorial
+The example this tutorial is based on is located in [this repository](https://github.com/neonlabsorg/neon-tutorials).
+
+By the end of this tutorial, you will deploy a contract describing an ERC-20 token to the Neon Devnet. You will then test this contract by transfering tokens to random generated wallet.
+
+### Step 1: Installation
+> **Note:** This page is just a quickstart based on a specific example program. For more details on installing Foundry, refer to the *[Foundry documentation](https://book.getfoundry.sh/getting-started/installation)*.
+
+Using Git, clone the example Foundry project from the remote repository and navigate to it:
+```sh
+git clone https://github.com/neonlabsorg/neon-tutorials
+cd neon-tutorials/foundry
+```
+
+Then, run the following command:
+```sh
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+```
+First command will install install Foundryup and `foundryup` will install the latest _(nightly)_ precompiled binaries: forge, cast, anvil, and chisel.
+
+Next action is to install required libraries:
+```sh
+forge install foundry-rs/forge-std --no-commit
+forge install openzeppelin/openzeppelin-contracts --no-commit
+```
+
+
+### Step 2: Set up the local environment file
+To interact with the soon-to-be-deployed contracts, you'll need to create new wallet. For this you can use MetaMask or any other wallet provider.
+
+In MetaMask this can be done by clicking on your current account's icon in the top right of the MetaMask extension pop-up, and then clicking on 'Create an Account' in the drop-down menu that appears. Then, obtain some Devnet NEON tokens for these accounts _(up to 100 NEON per account)_ using the [NeonFaucet](https://neonfaucet.org/) _(without having NEON balance you won't be able to sign and submit transactions)_. 
+
+To obtain the private key from MetaMask, click on the three vertical dots to the right of your currently displayed account name and wallet address. In this drop-down menu, click on 'Account Details', then on 'Export Private Key', and enter your password and click 'Confirm' to get access to the private key for that account.
+
+Now that you have your private key create a .env file and add these lines:
+```
+RPC_URL_DEVNET=https://devnet.neonevm.org
+CHAIN_ID_DEVNET=245022926
+RPC_URL_MAINNET=https://neon-proxy-mainnet.solana.p2p.org
+CHAIN_ID_MAINNET=245022934
+PRIVATE_KEY=<YOUR_PRIVATE_KEY>
+VERIFIER_URL_BLOCKSCOUT=https://neon-devnet.blockscout.com/api
+```
+
+After creating the `.env` file next command to run is:
+```
+source .env
+```
+
+
+### Step 3: Compile Contracts
+All of the contracts are located in the project's `src/` directory. Before these contracts can be run, they must first be compiled. To compile the project's contracts, run the following command:
+```sh
+forge build
+```
+
+After running this step, you should see output similar to the following:
+```
+[⠢] Compiling...
+[⠒] Compiling 24 files with 0.8.21
+[⠃] Solc 0.8.21 finished in 2.48s
+Compiler run successful!
+```
+
+Testing the smart contracts can be done with command:
+```sh
+forge test
+```
+
+
+### Step 4: Deploy Contracts
+To deploy the project's contracts, simply run the command :
+```sh
+forge create --rpc-url $RPC_URL_DEVNET --private-key $PRIVATE_KEY src/TestERC20/TestERC20.sol:TestERC20 --constructor-args "Test ERC20 Token" "TERC20" --legacy
+```
+
+After successfully running this step you should get console output similar to:
+```
+[⠰] Compiling...
+No files changed, compilation skipped
+Deployer: 0x4455E84Eaa56a01676365D4f86348B311969a4f4
+Deployed to: 0x5537599aa2F97Dd60a66342522a465A7f2e40Ff9
+Transaction hash: 0x6de9dab8a526cbac33008056d185b93dff725605efb791bf116b6bece4f0c486
+```
+
+
+### Step 6: Neonscan contract verification
+In this step we will verify our freshly deployed smart contract on our explorer Neonscan. This can be done by running the following command:
+```sh
+forge verify-contract --chain-id $CHAIN_ID_DEVNET <contract_address> src/TestERC20/TestERC20.sol:TestERC20 --verifier-url $VERIFIER_URL_BLOCKSCOUT --verifier blockscout
+```
+You have to replace `<contract_address>` with your smart contract address.
+
+After successfully running this step you should get console output similar to:
+```
+Start verifying contract `0x5537599aa2F97Dd60a66342522a465A7f2e40Ff9` deployed on 245022926
+
+Submitting verification for [src/TestERC20/TestERC20.sol:TestERC20] "0x5537599aa2F97Dd60a66342522a465A7f2e40Ff9".
+Submitted contract for verification:
+	Response: `OK`
+	GUID: `5537599aa2f97dd60a66342522a465a7f2e40ff9654118b3`
+	URL:
+        https://neon-devnet.blockscout.com/api?/address/0x5537599aa2f97dd60a66342522a465a7f2e40ff9
+```
+
+Now copy paste this link in your browser and also replace <CONTRACT_ADDRESS> with your freshly deployed contract address:
+
+https://neon-devnet.blockscout.com/address/<CONTRACT_ADDRESS>

--- a/docs/developing/deploy_facilities/using_hardhat.md
+++ b/docs/developing/deploy_facilities/using_hardhat.md
@@ -12,17 +12,17 @@ comment:
 Before beginning the tutorial below, make sure that you have properly [configured Hardhat](configure_hardhat) for the Neon EVM.
 
 ## How to Use Hardhat: A Tutorial
-The example this tutorial is based on is located in [this repository](https://github.com/neonlabsorg/examples/tree/main/simple-erc20-hardhat).
+The example this tutorial is based on is located in [this repository](https://github.com/neonlabsorg/neon-tutorials).
 
-By the end of this tutorial, you will deploy a contract describing an ERC-20 token to the Neon Devnet. You will then test this contract by minting 10000 test tokens that are deposited to the first wallet specified in the configuration file (see above), and then transferred to the second wallet address.
+By the end of this tutorial, you will deploy a contract describing an ERC-20 token to the Neon Devnet. You will then test this contract by transfering tokens to random generated wallet.
 
 ### Step 1: Installation
 > **Note:** This page is just a quickstart based on a specific example program. For more details on installing Hardhat, refer to the *[Hardhat documentation](https://hardhat.org/hardhat-runner/docs/getting-started#overview)*.
 
 Using Git, clone the example Hardhat project from the remote repository and navigate to it:
 ```sh
-git clone https://github.com/neonlabsorg/examples.git
-cd examples/simple-erc20-hardhat
+git clone https://github.com/neonlabsorg/neon-tutorials
+cd neon-tutorials/hardhat
 ```
 
 Then, run the following command:
@@ -37,58 +37,66 @@ npm cache clear --force
 npm install
 ```
 
-### Step 2: Set Up MetaMask Accounts
-To interact with the soon-to-be-deployed contracts, you'll need to create two new accounts in MetaMask. Before you begin, make sure that MetaMask is connected to the Neon Devnet.
+### Step 2: Set Up Signer Account
+To interact with the soon-to-be-deployed contracts, you'll need to create new wallet. For this you can use MetaMask or any other wallet provider.
 
-In MetaMask, create two new accounts. This can be done by clicking on your current account's icon in the top right of the MetaMask extension pop-up, and then clicking on 'Create an Account' in the drop-down menu that appears. Then, obtain some Devnet NEON tokens for these accounts (up to 100 NEON per account) using the [NeonFaucet](../utilities/faucet).
+In MetaMask this can be done by clicking on your current account's icon in the top right of the MetaMask extension pop-up, and then clicking on 'Create an Account' in the drop-down menu that appears. Then, obtain some Devnet NEON tokens for these accounts _(up to 100 NEON per account)_ using the [NeonFaucet](https://neonfaucet.org/) _(without having NEON balance you won't be able to sign and submit transactions)_. 
 
-Finally, copy the new accounts' private keys and paste them into the `hardhat.config.js` file described above, replacing the placeholder text in lines 11 and 12 of that file. To obtain the private keys, click on the three vertical dots to the right of your currently displayed account name and wallet address. In this drop-down menu, click on 'Account Details', then on 'Export Private Key', and enter your password and click 'Confirm' to get access to the private key for that account.
-
-> **Note:** When adding the private keys to the configuration file, make sure to add the prefix **0x** to the key obtained via MetaMask.
+Last action of this step is to copy the new wallet account private key and paste it into the `.env` file _(copy and rename `.env.example` to `.env` and place the private key there)_. To obtain the private key from MetaMask, click on the three vertical dots to the right of your currently displayed account name and wallet address. In this drop-down menu, click on 'Account Details', then on 'Export Private Key', and enter your password and click 'Confirm' to get access to the private key for that account.
 
 ### Step 3: Compile Contracts
 All of the contracts are located in the project's `contracts/` directory. Before these contracts can be run, they must first be compiled. To compile the project's contracts, run the following command:
 ```sh
-./node_modules/.bin/hardhat compile
+npx hardhat compile
 ```
 
 After running this step, you should see output similar to the following:
 ```
-Compiled 2 Solidity files successfully
+Compiled X Solidity files successfully
 ```
 
-### Step 4: Run Tests
-Make sure to test your code before you migrate it to the network. All test files should be located under the `test/` directory.
-
-To run all tests, simply run the command below:
-```sh
-./node_modules/.bin/hardhat test
-```
-
-This command compiles all the contracts in the `contracts/`, deploys them to the Neon Devnet, and runs all the tests in the `test/` directory. The output should look something like this:
-```
-  Testing TestERC20 contract
-    ✔ should successfully mint 10000 ERC20 in the first account (15967ms)
-    ✔ should transfer token correctly (31327ms)
-
-
-  2 passing (53s)
-```
-
-### Step 5: Deploy Contracts
+### Step 4: Deploy Contracts
 To deploy the project's contracts, simply run the command below to run the deployment script in the `scripts/` directory:
 ```sh
-./node_modules/.bin/hardhat run ./scripts/deploy.js
+npx hardhat run scripts/TestERC20/deploy.js --network neondevnet
+```
+
+This command compiles the contracts in the `contracts/` and deploys them to the Neon Devnet. The output should look something like this:
+```
+TestERC20 token deployed to <CONTRACT_ADDRESS>
+```
+
+If you wish to deploy on Neon Mainnet then just switch the `--network` parameter to `neonmainnet`.
+
+### Step 5: Testing Contracts
+This step in our example will also initiate transactions on Neon Devnet. Copy the new deployed smart contract address from the previous step and paste it inside file `scripts/TestERC20/transfer.js`. Next run the following command:
+```sh
+npx hardhat run scripts/TestERC20/transfer.js
 ```
 
 After running this command, you should see console output similar to the following:
 ```
-Deploying contracts with the account: 0xf71c4DACa893E5333982e2956C5ED9B648818376
-Contract address is:  0x49DCDEc367bba4271876259AE473890aa5AABc2e
-Minting  100000000000  tokens...
+Sender balance before transfer 1000000000000000000000n
+Receiver balance before transfer 0n
+Sender balance after transfer 990000000000000000000n
+Receiver balance after transfer 10000000000000000000n
 ```
+Which means that from our signer account we have sent 1000 * 10 ** 18 tokens to random generated wallet address.
 
-### Step 6: Connect Project to MetaMask
+### Step 6: Neonscan contract verification
+In this step we will verify our freshly deployed smart contract on our explorer Neonscan. This can be done by running the following command:
+```sh
+npx hardhat verify --network neondevnet <CONTRACT_ADDRESS>
+```
+You have to replace `<CONTRACT_ADDRESS>` with your smart contract address.
+
+This command will verify our smart contract on our [Devnet Neonscan](https://devnet.neonscan.org), but if you wish to verify a contract on the [Mainnet Neonscan](https://neonscan.org) then you have to change parameter `--network` to `neonmainnet`.
+
+
+### Step 7: Connect Project to MetaMask
 To import your project as an asset in MetaMask, follow the instructions [here](https://support.metamask.io/hc/en-us/articles/360015489031-How-to-add-unlisted-tokens-custom-tokens-in-MetaMask#h_01FWH492CHY60HWPC28RW0872H) and use the contract address from the previous step as the 'Token Contract Address' in MetaMask.
 
 Once you complete this final step, you will be able to see your new ERC-20 assets in the MetaMask profiles of the new test accounts.
+```sh
+npx hardhat verify --network neondevnet <CONTRACT_ADDRESS>
+```

--- a/docs/developing/deploy_facilities/using_remix.md
+++ b/docs/developing/deploy_facilities/using_remix.md
@@ -121,7 +121,7 @@ Fig. 7
 
 </div>
 
-### Step 5: Deploy a Smart Contract on Solana Devnet
+### Step 5: Deploy a Smart Contract on Neon Devnet
 In our case, there is only one smart contract to deploy, therefore it is automatically selected from the dropdown and Remix will automatically generate a transaction.  
 
 The `Account` field will display the amount in the wallet account. This data is taken from MetaMask.  
@@ -176,7 +176,7 @@ Fig. 12 — Final view of the Remix panel
 
 </div>
 
-Congratulations! You can now call methods of the helloWorld smart contract deployed on the Solana network. (Fig. 13 shows the result of your smart contract — the text string "Hello World!".)  
+Congratulations! You can now call methods of the helloWorld smart contract deployed on the Neon network. (Fig. 13 shows the result of your smart contract — the text string "Hello World!".)  
 
 <div className='neon-img-width-300' style={{textAlign: 'center'}}>
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -104,9 +104,7 @@ const sidebars = {
       label: 'Deploy Contracts',
       items: [
         'developing/deploy_facilities/using_hardhat',
-        'developing/deploy_facilities/using_truffle',
-        'developing/deploy_facilities/using_remix',
-        'developing/deploy_facilities/using_brownie'
+        'developing/deploy_facilities/using_remix'
       ]
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -104,6 +104,7 @@ const sidebars = {
       label: 'Deploy Contracts',
       items: [
         'developing/deploy_facilities/using_hardhat',
+        'developing/deploy_facilities/using_foundry',
         'developing/deploy_facilities/using_remix'
       ]
     },


### PR DESCRIPTION
@0xlucian @sukanyaparashar @m4sterbunny hi, this PR includes:

1. Changes inside at [Deploy with Hardhat](https://docs.neonfoundation.io/docs/developing/deploy_facilities/using_hardhat) page
2. Added new page of how to deploy contracts with Foundry
3. Deprecated Truffle & Brownie. The reason for this is that Truffle is officially getting deprecated _( ss attached below )_ and Brownie installation is not working properly. I tried installing it in different ways, but failed and I've saw that they're inactive in github PRs and issues. Also last time their library was updated is end of 2022, plus it's very famous framework at all! imo 2/3 of devs use hardhat the rest use foundry.
<img width="1136" alt="Screenshot 2023-11-03 at 10 36 38" src="https://github.com/neonlabsorg/neon-evm.docs/assets/45385208/7c25da82-528f-4407-9b10-b0c3a876cc7f">

