### PR TITLE
fix configure hardhat and add configure foundry

### DIFF
--- a/docs/developing/deploy_facilities/configure_foundry.md
+++ b/docs/developing/deploy_facilities/configure_foundry.md
@@ -1,0 +1,33 @@
+---
+title: "Configure Foundry"
+proofedDate: na
+iterationBy: na
+includedInSite: true
+approvedBy: na
+comment: 
+---
+
+Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
+
+Details on how to use the Foundry framework will not be described here. You can find all necessary information by reading the [Foundry documentation](https://book.getfoundry.sh).
+
+For a tutorial on how to use Foundry to deploy on the Neon EVM, see [here](/docs/developing/deploy_facilities/using_foundry).
+
+## Prerequisites
+Before you start, make sure the following software is installed on your device:
+  * `cURL` - You will need cURL to install Foundery, some operating systems ship curl by default. If your terminal doesn't support it you have to install it.
+
+## The Foundry Configuration
+Unlike other toolkits Foundry doesn't have a config file which is holding the chain parameters, instead everything is being passed into commands. This command is an example of how to deploy a smart contract:
+```
+forge create --rpc-url $RPC_URL_DEVNET \
+--private-key $PRIVATE_KEY \
+--constructor-args "Test ERC20 Token" "TERC20" --legacy \
+src/TestERC20/TestERC20.sol:TestERC20
+```
+
+The parameters for `forge create` command include:
+* `--rpc-url`: RPC URL
+* `--private-key`: The private key of the transaction signer
+* `--constructor-args`: The constructor arguments to be passed to the contract that is being deployed
+* `--legacy`: This parameter is being passed to use legacy transactions _( Neon EVM currently doesn't support EIP-1559 transactions )_

--- a/docs/developing/deploy_facilities/configure_hardhat.md
+++ b/docs/developing/deploy_facilities/configure_hardhat.md
@@ -15,16 +15,7 @@ For a tutorial on how to use Hardhat to deploy on the Neon EVM, see [here](/docs
 
 ## Prerequisites
 Before you start, make sure the following software is installed on your device:
-  * `NodeJS v8.9.4` or later
-  * `Web3 v1.2.0` or later
-
-Also make sure that the following is true:
-  * MetaMask is installed on your device. To install MetaMask, follow [this guide](wallet/metamask_setup.md#installing-metamask). 
-  * MetaMask is configured for the Neon EVM.
-
-## Network Configurations
-  * [Solana cluster](https://docs.solana.com/clusters) is accessed via a proxy.
-  * Solana works in test mode and the proxy interacts with it through Neon EVM.
+  * `NodeJS`
 
 ## The Hardhat Configuration File
 To deploy a contract to the Neon EVM with Hardhat, some Neon-specific information must be specified in a configuration file. This configuration file is called `hardhat.config.js` and is located at the root of your project directory. This file is a JavaScript file and can execute any code necessary to create your configuration. Its file schema, variables, and other documentation can be found on the [official Hardhat website](https://hardhat.org/hardhat-runner/docs/config). Please note that the deployer wallet address needs to have enough NEON tokens to cover the gas cost of the deployment. NEON tokens for Devnet can be obtained using the [NeonFaucet](developing/utilities/faucet.md).
@@ -33,43 +24,59 @@ The following is a full example, configured for the example below, of the `hardh
 
 ##### hardhat.config.js
 ```js
-require("@nomiclabs/hardhat-waffle");
+require("@nomicfoundation/hardhat-toolbox");
+require("dotenv").config();
 
-const proxy_url = 'https://devnet.neonevm.org';
-const network_id = 245022926;
-
-// Private keys for test accounts
-// NOTE: Replace these placeholders with your own and make sure the accounts have non-zero NEON balances
-const privateKeys = [
-  "0xPLACEHOLDER1",
-  "0xPLACEHOLDER2"
-];
-
+/** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "0.8.4",
-  defaultNetwork: 'neonlabs',
-  networks: {
-    neonlabs: {
-      url: proxy_url,
-      accounts: privateKeys,
-      network_id: network_id,
-      chainId: network_id,
-      allowUnlimitedContractSize: false,
-      timeout: 1000000,
-      isFork: true
+    solidity: "0.8.21",
+    defaultNetwork: "neondevnet",
+    etherscan: {
+        apiKey: {
+            neonevm: "test"
+        },
+        customChains: [
+            {
+                network: "neonevm",
+                chainId: 245022926,
+                urls: {
+                    apiURL: "https://devnet-api.neonscan.org/hardhat/verify",
+                    browserURL: "https://devnet.neonscan.org"
+                }
+            },
+            {
+                network: "neonevm",
+                chainId: 245022934,
+                urls: {
+                    apiURL: "https://api.neonscan.org/hardhat/verify",
+                    browserURL: "https://neonscan.org"
+                }
+            }
+        ]
+    },
+    networks: {
+        neondevnet: {
+            url: "https://devnet.neonevm.org",
+            accounts: [process.env.PRIVATE_KEY_OWNER],
+            chainId: 245022926
+        },
+        neonmainnet: {
+            url: "https://neon-proxy-mainnet.solana.p2p.org",
+            accounts: [process.env.PRIVATE_KEY_OWNER],
+            chainId: 245022934
+        }
     }
-  }
 };
 ```
 
 The parameters for `module.exports` include:
 * `solidity`: version of Solidity used
-* `defaultNetwork`: 'neonlabs'
-* `networks`:
-  * `neonlabs`:
-    * `url`: proxy URL
-    * `accounts`: an array of deployer's private keys
-    * `network_id`: the network's network ID
+* `defaultNetwork`: which chain will be used by default for deploying or testing
+* `etherscan`: settings used to verify contracts on-chain [read more here](https://hardhat.org/hardhat-runner/docs/guides/verifying)
+* `networks`: the list of the supported networks
+  * `neondevnet`:
+    * `url`: RPC URL
+    * `accounts`: an array of deployer's private keys, in the current example PRIVATE_KEY_OWNER is stored inside .env file
     * `chainId`: the network's chain ID
 
-Note that `proxy_url`, `network_id`, and `chainId` can be retrieved from the RPC endpoints table and/or [chainlist.org](https://chainlist.org/).
+Note that `url` and `chainId` can be retrieved from the RPC endpoints table and/or [Chainlist](https://chainlist.org/?search=Neon+EVM&testnets=true).

--- a/sidebars.js
+++ b/sidebars.js
@@ -75,8 +75,7 @@ const sidebars = {
       label: 'Configure Dev Tools',
       items: [
         'developing/deploy_facilities/configure_hardhat',
-        'developing/deploy_facilities/configure_truffle',
-        'developing/deploy_facilities/configure_brownie'
+        'developing/deploy_facilities/configure_foundry'
       ]
     },
     {


### PR DESCRIPTION
@0xlucian @sukanyaparashar @m4sterbunny hi, this PR includes:

1. Fixed on [configure hardhat page](https://docs.neonfoundation.io/docs/developing/deploy_facilities/configure_hardhat)
2. Deprecate configure Truffle & Brownie, because they're deprecated
3. Add configure foundry page