### PR TITLE
spurious edit to fix a broken link that is not broken on local build

### DIFF
--- a/docs/developing/deploy_facilities/configure_foundry.md
+++ b/docs/developing/deploy_facilities/configure_foundry.md
@@ -35,4 +35,5 @@ The parameters for `forge create` command include:
 
 ## What next?
 
-See the [tutorial on how to use Foundry to deploy to Neon EVM](/docs/developing/deploy_facilities/using_foundry).
+See the [tutorial on how to use Foundry](/docs/developing/deploy_facilities/using_foundry) to deploy to Neon EVM.
+


### PR DESCRIPTION
The broken link reported here 
https://github.com/neonlabsorg/neon-evm.docs/actions/runs/6983509236/job/19004730708
does not appear to be broken in my build locally

relocating link to see if error is repeatable