### PR TITLE
Update basic.md *Step 3: Run the Docker container

### DIFF
--- a/docs/operating/basic.md
+++ b/docs/operating/basic.md
@@ -46,10 +46,10 @@ Working at the root folder of the proxy-model.py codebase:
 
 3.1 Pull the Docker image:
 
-   In case you intend to use an external Solana node:
-  ```bash
-        docker-compose -f ./docker-compose/docker-compose-remote-solana.yml pull
-  ```
+In case you intend to use an external Solana node:
+```bash
+docker-compose -f ./docker-compose/docker-compose-remote-solana.yml pull
+```
 Otherwise:
 ```bash
 docker-compose -f ./docker-compose/docker-compose-ci.yml pull

--- a/docs/operating/basic.md
+++ b/docs/operating/basic.md
@@ -46,16 +46,25 @@ Working at the root folder of the proxy-model.py codebase:
 
 3.1 Pull the Docker image:
 
+   In case you intend to use an external Solana node:
+  ```bash
+        docker-compose -f ./docker-compose/docker-compose-remote-solana.yml pull
+  ```
+Otherwise:
 ```bash
-docker-compose -f ./docker-compose/docker-compose-test.yml pull
+docker-compose -f ./docker-compose/docker-compose-ci.yml pull
 ```
 
 3.2 Start the proxy with:
 
+In case you intend to use an external Solana node:
 ```bash
-docker-compose -f ./docker-compose/docker-compose-test.yml up
+docker-compose -f ./docker-compose/docker-compose-remote-solana.yml up
 ```
-
+Otherwise:
+```bash
+docker-compose -f ./docker-compose/docker-compose-ci.yml up
+```
 
 <Tabs>
   <TabItem value="View" label="Code" default>


### PR DESCRIPTION
Lines 48-68:
Instead of docker-compose-test.yml user can choose either all-in-one image docker-compose-ci.yml or adopted image for external Solana docker-compose-remote-solana.yml.

Before:
<img width="534" alt="image" src="https://github.com/neonlabsorg/neon-evm.docs/assets/137310889/3667d989-ac11-4a47-a1a5-e24057db5bf6">

Changed to:
<img width="597" alt="image" src="https://github.com/neonlabsorg/neon-evm.docs/assets/137310889/d8dd9b20-d514-4c0f-8aac-52128937f69e">
