### PR TITLE
Replace the old pull service Pyth integration example with the new pusher service example of reading Pyth Solana price feeds

### DIFF
--- a/docs/developing/integrate/oracles/integrating_pyth.md
+++ b/docs/developing/integrate/oracles/integrating_pyth.md
@@ -120,12 +120,6 @@ PRIVATE_KEY_OWNER=`YOUR_PRIVATE_KEY`
 Replace `YOUR_PRIVATE_KEY` with your data.
 :::
 
-2.3 Run:
-
-```
-source .env
-```
-
 ### Step 3: Compile Contracts
 
 All of the contracts are located in the project's `contracts/` directory. Before these contracts can be run, they must first be compiled. To compile the project's contracts, run the following command:
@@ -159,6 +153,8 @@ Result(2) [ 13086946350n, 1714620699n ] solPrice
 Result(2) [ 292996614519n, 1714620700n ] ethPrice
 Result(2) [ 5761891500000n, 1714620702n ] btcPrice
 ```
+
+**The 1st parameter in the resulting array is the price and the 2nd parameter is the timestamp of the last price push.**
 
 :::info
 To deploy on Neon EVM Mainnet, change `--network neondevnet` to `--network neonmainnet` in the command line.

--- a/docs/developing/integrate/oracles/integrating_pyth.md
+++ b/docs/developing/integrate/oracles/integrating_pyth.md
@@ -172,10 +172,11 @@ Result(3) [ 299735750000n, 1714670448n, 1n ] ethPrice
 Result(3) [ 5919709374999n, 1714670448n, 1n ] btcPrice
 ```
 
-> The result represents an array with the following parameters -
-> 1st parameter - Price
-> 2nd parameter - Timestamp of the last price push
-> 3rd parameter - Status (0 = UNKNOWN, 1 = TRADING, 2 = HALTED, 3 = AUCTION)
+> The result represents an array with the following parameters:
+>
+> - 1st parameter - Price
+> - 2nd parameter - Timestamp of the last price push
+> - 3rd parameter - Status (0 = UNKNOWN, 1 = TRADING, 2 = HALTED, 3 = AUCTION)
 >
 > For validating the correct price, a check for the timestamp or status can be implemented in the code.
 

--- a/docs/developing/integrate/oracles/integrating_pyth.md
+++ b/docs/developing/integrate/oracles/integrating_pyth.md
@@ -158,7 +158,7 @@ Compiled 23 Solidity files successfully
 
 ### Step 4: Deploy Contract
 
-`NEON_COFIG` contains the proxy contract addresses on Devnet and Mainnet, and the price ids for reading Pyth prices.
+`NEON_CONFIG` contains the proxy contract addresses on Devnet and Mainnet, and the price ids for reading Pyth prices.
 
 To deploy the project's contract for Pyth price, simply run the command below to run the deployment script in the `scripts/` directory:
 
@@ -182,6 +182,10 @@ LINK_USD Result(4) [ 1930030964n, 2261590n, -8n, 1711403472n ]
 USDC_USD Result(4) [ 99989324n, 49324n, -8n, 1711403472n ]
 USDT_USD Result(4) [ 100035012n, 35012n, -8n, 1711403472n ]
 ```
+
+:::info
+To deploy on Neon EVM Mainnet, change `--network neondevnet` to `--network neonmainnet` in the command line.
+:::
 
 It's **strongly recommended** that you follow the [consumer best practices](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices) when consuming Pyth data.
 

--- a/docs/developing/integrate/oracles/integrating_pyth.md
+++ b/docs/developing/integrate/oracles/integrating_pyth.md
@@ -11,18 +11,18 @@ comment: todo the <!-- https://github.com/pyth-network/pyth-neon_ --> is an arch
 
 - First call `pyth.updatePriceFeeds`
 - Next call `pyth.getPrice`
-- Find price feed addresses on [Devnet](https://pyth.network/developers/price-feed-ids/#neon-evm-devnet) and [Mainnet](https://pyth.network/developers/price-feed-ids/#neon-evm-mainnet)
+- Find price feed addresses on [Devnet](https://pyth.network/developers/price-feed-ids#solana-devnet) and [Mainnet](https://pyth.network/developers/price-feed-ids#solana-mainnet-beta)
 
 ## Introduction
 
-[Pyth](https://pyth.network/) is an open-source real-time on-chain market data feed. To use Pyth prices, you must call the function `updatePriceFeeds `, which submits the price update data to the Pyth contract in your target chain. 
+[Pyth](https://pyth.network/) is an open-source real-time on-chain market data feed. To use Pyth prices, you must call the function `updatePriceFeeds `, which submits the price update data to the Pyth contract in your target chain.
 
 > Your contract interacts with the Pyth contract to request a data refresh. This interaction also provides an opportunity to validate that the updates you received are authentic.
 
 Next, your contract should query the Pyth Contract that holds this updated data for the token prices you require. The price feed IDs are available for Neon EVM:
-- [Pyth on Devnet](https://pyth.network/developers/price-feed-ids/#neon-evm-devnet)
-- [Pyth on Mainnet](https://pyth.network/developers/price-feed-ids/#neon-evm-mainnet)
 
+- [Pyth on Devnet](https://pyth.network/developers/price-feed-ids#solana-devnet)
+- [Pyth on Mainnet](https://pyth.network/developers/price-feed-ids#solana-mainnet-beta)
 
 ## How to integrate with the Pyth contract
 

--- a/docs/developing/integrate/oracles/integrating_pyth.md
+++ b/docs/developing/integrate/oracles/integrating_pyth.md
@@ -13,7 +13,7 @@ import mm_p_key from '@site/static/img/doc-images/developing/deploy_facilities/f
 
 - First call `pyth.updatePriceFeeds`
 - Next call `pyth.getPrice`
-- Find price feed addresses on [Devnet](https://pyth.network/developers/price-feed-ids#solana-devnet) and [Mainnet](https://pyth.network/developers/price-feed-ids#solana-mainnet-beta)
+- Find price feed IDs on Neon EVM Mainnet and Devnet [here](https://pyth.network/developers/price-feed-ids#pyth-evm-stable).
 
 ## Introduction
 
@@ -21,10 +21,7 @@ import mm_p_key from '@site/static/img/doc-images/developing/deploy_facilities/f
 
 > Your contract interacts with the Pyth contract to request a data refresh. This interaction also provides an opportunity to validate that the updates you received are authentic.
 
-Next, your contract should query the Pyth Contract that holds this updated data for the token prices you require. The price feed IDs are available for Neon EVM:
-
-- [Pyth on Devnet](https://pyth.network/developers/price-feed-ids#solana-devnet)
-- [Pyth on Mainnet](https://pyth.network/developers/price-feed-ids#solana-mainnet-beta)
+Next, your contract should query the Pyth Contract that holds this updated data for the token prices you require. The price feed IDs are available for Neon EVM [here](https://pyth.network/developers/price-feed-ids#pyth-evm-stable).
 
 ## Boilerplate contract
 
@@ -77,7 +74,7 @@ The constructor in the smart contract takes the proxy contract address as an arg
 
 | Location | Proxy Contract address                     |
 | :------- | :----------------------------------------- |
-| Devnet   | 0x2FF312f50689ad279ABb164dB255Eb568733BD6c |
+| Devnet   | 0x0708325268dF9F66270F1401206434524814508b |
 | Mainnet  | 0x7f2db085efc3560aff33865dd727225d91b4f9a5 |
 
 ## How to integrate with the Pyth contract
@@ -161,7 +158,7 @@ Compiled 23 Solidity files successfully
 
 ### Step 4: Deploy Contract
 
-`NEON_COFIG` contains the proxy contract addresses on Devnet and Mainnet, and the price ids for reading Pyth prices from Solana.
+`NEON_COFIG` contains the proxy contract addresses on Devnet and Mainnet, and the price ids for reading Pyth prices.
 
 To deploy the project's contract for Pyth price, simply run the command below to run the deployment script in the `scripts/` directory:
 
@@ -178,7 +175,12 @@ npx hardhat run scripts/TestPyth/getPrice.js --network neondevnet
 The output should look like:
 
 ```
-
+BTC_USD Result(4) [ 6997401314334n, 3802014633n, -8n, 1711403472n ]
+ETH_USD Result(4) [ 359529041250n, 172892485n, -8n, 1711403472n ]
+SOL_USD Result(4) [ 19007398487n, 20190280n, -8n, 1711403472n ]
+LINK_USD Result(4) [ 1930030964n, 2261590n, -8n, 1711403472n ]
+USDC_USD Result(4) [ 99989324n, 49324n, -8n, 1711403472n ]
+USDT_USD Result(4) [ 100035012n, 35012n, -8n, 1711403472n ]
 ```
 
 It's **strongly recommended** that you follow the [consumer best practices](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices) when consuming Pyth data.


### PR DESCRIPTION
This PR adds the new example repository for Pyth integration with reading Pyth Solana price feeds natively and also updates the price feeds link.