### PR TITLE
Add --skip-simulation parameter information to the Foundry pages

### DIFF
--- a/docs/developing/deploy_facilities/configure_foundry.md
+++ b/docs/developing/deploy_facilities/configure_foundry.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Foundry"
+title: 'Configure Foundry'
 proofedDate: 20231116
 iterationBy: na
 includedInSite: true
@@ -14,11 +14,27 @@ Foundry is a blazing fast, portable,modular toolkit for Ethereum application dev
 This page details several parameters required to configure Foundry. The Foundry framework isn't described here; find that in the [Foundry documentation](https://book.getfoundry.sh).
 
 ## Prerequisites
+
 - cURL
 
 ## Foundry configuration
 
-Unlike other toolkits, Foundry doesn't have a config file to hold the chain parameters, instead, parameters are passed into commands. For example, this command deploys a smart contract:
+Unlike other toolkits, Foundry doesn't have a config file to hold the chain parameters, instead, parameters are passed into commands.
+
+1. The following command deploys a contract using a script:
+
+```
+forge script script/TestERC20/DeployTestERC20.s.sol:DeployTestERC20Script --broadcast --rpc-url $RPC_URL_DEVNET --legacy --skip-simulation
+```
+
+The parameters for `forge script` command include:
+
+- `--rpc-url`: RPC URL
+- `--skip-simulation`: This parameter skips the on-chain simulation which doesn't work on Neon EVM.
+- `--broadcast`: This parameter broadcasts the transaction.
+- `--legacy`: This parameter is being passed to use legacy transactions _(Neon EVM currently [doesn't support EIP-1559 transactions](/docs/evm_compatibility/overview#shared-standards-and-features))_
+
+2. The following command deploys a contract directly without a script:
 
 ```
 forge create --rpc-url $RPC_URL_DEVNET \
@@ -28,10 +44,10 @@ src/TestERC20/TestERC20.sol:TestERC20
 ```
 
 The parameters for `forge create` command include:
-* `--rpc-url`: RPC URL
-* `--private-key`: The private key of the transaction signer
-* `--constructor-args`: The constructor arguments to be passed to the contract that is being deployed
-* `--legacy`: This parameter is being passed to use legacy transactions _(Neon EVM currently [doesn't support EIP-1559 transactions](/docs/evm_compatibility/overview#shared-standards-and-features))_
 
+- `--rpc-url`: RPC URL
+- `--private-key`: The private key of the transaction signer
+- `--constructor-args`: The constructor arguments to be passed to the contract that is being deployed
+- `--legacy`: This parameter is being passed to use legacy transactions _(Neon EVM currently [doesn't support EIP-1559 transactions](/docs/evm_compatibility/overview#shared-standards-and-features))_
 
-## What next? See the [tutorial on how to use Foundry](/docs/developing/deploy_facilities/using_foundry) to deploy to Neon EVM.
+### What next? See the [tutorial on how to use Foundry](/docs/developing/deploy_facilities/using_foundry) to deploy on Neon EVM.

--- a/docs/developing/deploy_facilities/using_foundry.md
+++ b/docs/developing/deploy_facilities/using_foundry.md
@@ -209,6 +209,8 @@ Total Paid: 0.0034876870402 ETH (20000 gas * avg 174.38435201 gwei)
 ```
 
 :::important
+`--skip-simulation` parameter skips the on-chain simulation which doesn't work on Neon EVM.
+
 The native token displayed above should be NEON instead of ETH and the unit should be Galan instead of gwei (It is not possible to customize the display).
 :::
 


### PR DESCRIPTION
This PR adds the `--skip-simulation` parameter information in the **Configure Foundry** and **Deploy using Foundry** pages.