### PR TITLE
Add POPCAT to the ERC20 token list

### DIFF
--- a/docs/tokens/token_list.md
+++ b/docs/tokens/token_list.md
@@ -54,6 +54,7 @@ The following tables provide the addresses of ERC-20 interface contracts for the
 | <img src="https://raw.githubusercontent.com/neonlabsorg/token-list/master/assets/jupiter-logo.svg" className="coin-icon" />              | JUP             | `0x9F0fCE2AB962984b1EE50108A8510eA190BeEb8d` | `JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN`  |
 | <img src="https://raw.githubusercontent.com/neonlabsorg/token-list/master/assets/dogwifhat-logo.png" className="coin-icon" />            | $WIF            | `0xF86934c2b05c31f3bBE3BCd6E3a8aA7790cAd9c1` | `EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm` |
 | <img src="https://raw.githubusercontent.com/neonlabsorg/token-list/master/assets/wen-logo.png" className="coin-icon" />                  | WEN             | `0xc61e8aB62666D25F0854C5723587507A7E92E289` | `WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk`  |
+| <img src="https://raw.githubusercontent.com/neonlabsorg/token-list/master/assets/popcat-logo.svg" className="coin-icon" />               | POPCAT          | `0xb89c62e960457d1d2c5f20135bedfd215d2466de` | `7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr` |
 
 </TabItem>
 <TabItem value="devnet" label="Devnet">


### PR DESCRIPTION
This PR adds `POPCAT` token to the ERC20 token list in the docs. The reference about the details can be found here https://github.com/neonlabsorg/token-list/blob/main/tokenlist.json.