### PR TITLE
Changes in Neon Proxy API and JSON-RPC API Methods according to the Neon Proxy update on MainNet

### DIFF
--- a/docs/api/neon-api.mdx
+++ b/docs/api/neon-api.mdx
@@ -107,14 +107,14 @@ The method [neon_gasPrice](#get-neon-gas-price) returns data on gas price.
 
 ### 3. Neon transaction data
 
-- [neon_getLogs](#get-transaction-logs): returns transaction log data
-- [neon_getTransactionReceipt](#get-transaction-receipt): returns transaction receipt data
-- [neon_getSolanaTransactionByNeonTransaction](#get-solana-transactions): returns a list of Solana transactions that correspond to a given Neon transaction
-- [neon_emulate](#emulate-a-neon-transaction): returns details of an emultated transaction
+- [neon_getLogs](#get-transaction-logs--): returns transaction log data
+- [neon_getTransactionReceipt](#get-transaction-receipt--): returns transaction receipt data
+- [neon_getSolanaTransactionByNeonTransaction](#get-solana-transactions--): returns a list of Solana transactions that correspond to a given Neon transaction
+- [neon_emulate](#emulate-a-neon-transaction--): returns details of an emultated transaction
 
 ### 4. Parameters
 
-[neon_getEvmParams](#get-parameters): returns parameters of the Neon EVM program deployed on Solana.
+[neon_getEvmParams](#get-parameters--): returns parameters of the Neon EVM program deployed on Solana.
 
 ## Get versions
 
@@ -255,7 +255,7 @@ The `neon_getTransactionReceipt` method returns transaction receipt data.
 </TabItem>
 </Tabs>
 
-### Get Solana transactions :construction_worker:
+### Get Solana transactions 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 The `neon_getSolanaTransactionByNeonTransaction` method returns a list of Solana transactions that correspond to a given Neon transaction.
 

--- a/docs/api/neon-api.mdx
+++ b/docs/api/neon-api.mdx
@@ -114,7 +114,7 @@ The method [neon_gasPrice](#get-neon-gas-price) returns data on gas price.
 
 ### 4. Parameters
 
-[neon_getEvmParams](#get-parameters--): returns parameters of the Neon EVM program deployed on Solana.
+[neon_getEvmParams](#get-parameters): returns parameters of the Neon EVM program deployed on Solana.
 
 ## Get versions
 
@@ -186,7 +186,7 @@ The [JSON](#get-neon-gas-price-response-as-json) for this response schema is ava
 
 ## Get transaction data
 
-### Get transaction logs <!-- The text :construction_worker: is hidden -->
+### Get transaction logs<!-- The text :construction_worker: is hidden -->
 
 The `neon_getLogs` method returns transaction log data. This is an extended variant of the [eth_getLogs](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) API method.
 

--- a/docs/api/neon-api.mdx
+++ b/docs/api/neon-api.mdx
@@ -114,7 +114,7 @@ The method [neon_gasPrice](#get-neon-gas-price) returns data on gas price.
 
 ### 4. Parameters
 
-[neon_getEvmParams](#get-parameters--): returns parameters of the Neon EVM program deployed on Solana.
+[neon_getEvmParams](#get-parameters): returns parameters of the Neon EVM program deployed on Solana.
 
 ## Get versions
 
@@ -186,7 +186,7 @@ The [JSON](#get-neon-gas-price-response-as-json) for this response schema is ava
 
 ## Get transaction data
 
-### Get transaction logs <!-- The text :construction_worker: is hidden -->
+### Get transaction logs 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 The `neon_getLogs` method returns transaction log data. This is an extended variant of the [eth_getLogs](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) API method.
 
@@ -221,7 +221,7 @@ The `neon_getLogs` method returns transaction log data. This is an extended vari
 </TabItem>
 </Tabs>
 
-### Get transaction receipt <!-- The text :construction_worker: is hidden -->
+### Get transaction receipt 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 The `neon_getTransactionReceipt` method returns transaction receipt data.
 
@@ -255,7 +255,7 @@ The `neon_getTransactionReceipt` method returns transaction receipt data.
 </TabItem>
 </Tabs>
 
-### Get Solana transactions <!-- The text :construction_worker: is hidden -->
+### Get Solana transactions :construction_worker:
 
 The `neon_getSolanaTransactionByNeonTransaction` method returns a list of Solana transactions that correspond to a given Neon transaction.
 
@@ -290,7 +290,7 @@ The `neon_getSolanaTransactionByNeonTransaction` method returns a list of Solana
 </Tabs>
 
 
-## Emulate a Neon transaction <!-- The text :construction_worker: is hidden -->
+## Emulate a Neon transaction 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 The `neon_emulate` method returns details of an emultated transaction.
 
@@ -321,7 +321,8 @@ The [JSON](#get-neon-emulate-response-as-json) for this response schema is avail
 </TabItem>
 </Tabs>
 
-## Get Parameters <!-- The text :construction_worker: is hidden -->
+## Get Parameters 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
+
 
 The `neon_getEvmParams` method returns details of the EVM.
 

--- a/docs/api/neon-api.mdx
+++ b/docs/api/neon-api.mdx
@@ -114,7 +114,7 @@ The method [neon_gasPrice](#get-neon-gas-price) returns data on gas price.
 
 ### 4. Parameters
 
-[neon_getEvmParams](#get-parameters): returns parameters of the Neon EVM program deployed on Solana.
+[neon_getEvmParams](#get-parameters--): returns parameters of the Neon EVM program deployed on Solana.
 
 ## Get versions
 
@@ -186,7 +186,7 @@ The [JSON](#get-neon-gas-price-response-as-json) for this response schema is ava
 
 ## Get transaction data
 
-### Get transaction logs 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
+### Get transaction logs <!-- The text :construction_worker: is hidden -->
 
 The `neon_getLogs` method returns transaction log data. This is an extended variant of the [eth_getLogs](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) API method.
 
@@ -221,7 +221,7 @@ The `neon_getLogs` method returns transaction log data. This is an extended vari
 </TabItem>
 </Tabs>
 
-### Get transaction receipt 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
+### Get transaction receipt <!-- The text :construction_worker: is hidden -->
 
 The `neon_getTransactionReceipt` method returns transaction receipt data.
 
@@ -255,7 +255,7 @@ The `neon_getTransactionReceipt` method returns transaction receipt data.
 </TabItem>
 </Tabs>
 
-### Get Solana transactions :construction_worker:
+### Get Solana transactions <!-- The text :construction_worker: is hidden -->
 
 The `neon_getSolanaTransactionByNeonTransaction` method returns a list of Solana transactions that correspond to a given Neon transaction.
 
@@ -290,7 +290,7 @@ The `neon_getSolanaTransactionByNeonTransaction` method returns a list of Solana
 </Tabs>
 
 
-## Emulate a Neon transaction 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
+## Emulate a Neon transaction <!-- The text :construction_worker: is hidden -->
 
 The `neon_emulate` method returns details of an emultated transaction.
 
@@ -321,8 +321,7 @@ The [JSON](#get-neon-emulate-response-as-json) for this response schema is avail
 </TabItem>
 </Tabs>
 
-## Get Parameters 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
-
+## Get Parameters <!-- The text :construction_worker: is hidden -->
 
 The `neon_getEvmParams` method returns details of the EVM.
 

--- a/docs/api/neon-api.mdx
+++ b/docs/api/neon-api.mdx
@@ -42,7 +42,7 @@ import neon_solanaVersion_response from "@site/static/schemas/neon-api/v1/neon_s
 
 :::danger
 
-This page is wip :construction_worker:
+This page is wip 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 :::
 
@@ -186,7 +186,7 @@ The [JSON](#get-neon-gas-price-response-as-json) for this response schema is ava
 
 ## Get transaction data
 
-### Get transaction logs :construction_worker:
+### Get transaction logs 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 The `neon_getLogs` method returns transaction log data. This is an extended variant of the [eth_getLogs](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) API method.
 
@@ -221,7 +221,7 @@ The `neon_getLogs` method returns transaction log data. This is an extended vari
 </TabItem>
 </Tabs>
 
-### Get transaction receipt :construction_worker:
+### Get transaction receipt 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 The `neon_getTransactionReceipt` method returns transaction receipt data.
 
@@ -290,7 +290,7 @@ The `neon_getSolanaTransactionByNeonTransaction` method returns a list of Solana
 </Tabs>
 
 
-## Emulate a Neon transaction :construction_worker:
+## Emulate a Neon transaction 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 The `neon_emulate` method returns details of an emultated transaction.
 
@@ -321,10 +321,10 @@ The [JSON](#get-neon-emulate-response-as-json) for this response schema is avail
 </TabItem>
 </Tabs>
 
-## Get Parameters :construction_worker:
+## Get Parameters 👷 <!-- The text :construction_worker: is sobstituted with the refenced symbol 👷 -->
 
 
-The `neon_getEVMParams` method returns details of the EVM.
+The `neon_getEvmParams` method returns details of the EVM.
 
 <Tabs>
 <TabItem value="RSchema" label="Request" default>
@@ -333,7 +333,7 @@ The [JSON](#get-neon-evm-parameters-request-as-json) for this request schema is 
 
 <JSONSchemaViewer schema={ neon_getEvmParams_request  } viewerOptions={{ showExamples: true }} />
 
-#### Get Neon EVM parameters request as JSON
+The `neon_getEvmParams` method returns details of the EVM.
 
 <CodeBlock language="json">{JSON.stringify(neon_getEvmParams_request, null, 2)}</CodeBlock>
 

--- a/docs/api/neon-api.mdx
+++ b/docs/api/neon-api.mdx
@@ -114,7 +114,7 @@ The method [neon_gasPrice](#get-neon-gas-price) returns data on gas price.
 
 ### 4. Parameters
 
-[neon_getEvmParams](#get-parameters): returns parameters of the Neon EVM program deployed on Solana.
+[neon_getEvmParams](#get-parameters--): returns parameters of the Neon EVM program deployed on Solana.
 
 ## Get versions
 
@@ -186,7 +186,7 @@ The [JSON](#get-neon-gas-price-response-as-json) for this response schema is ava
 
 ## Get transaction data
 
-### Get transaction logs<!-- The text :construction_worker: is hidden -->
+### Get transaction logs <!-- The text :construction_worker: is hidden -->
 
 The `neon_getLogs` method returns transaction log data. This is an extended variant of the [eth_getLogs](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) API method.
 

--- a/docs/evm_compatibility/json_rpc_api_methods.md
+++ b/docs/evm_compatibility/json_rpc_api_methods.md
@@ -62,7 +62,8 @@ Split this into standard ETH-supported methods // Not supported methods // AND a
 | 39  | [eth_getTransactionByBlockNumberAndIndex](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionbyblocknumberandindex) | _Returns information about a transaction by block number and transaction index position_                                                                      | ![done](img/done.ico)              |
 | 40  | [eth_getTransactionReceipt](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionrecepit)               | _Returns the receipt of a transaction by transaction hash_                                                                                                    | ![done](img/done.ico)              |
 
-
+Methods `eth_getTransactionByHash`,  `eth_getTransactionByBlockHashAndIndex`, `eth_getTransactionByBlockNumberAndIndex`, `eth_getBlockByHash` and `eth_getBlockByNumber` also return the `chainId` property in addition to the [specified](https://ethereum.org/en/developers/docs/apis/json-rpc) output.
+wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
 ## JSON-RPC methods according to the [Web3 Module API](https://openethereum.github.io/JSONRPC-web3-module)
 
 | Num | Method                                                                                       | Description                                                            | Status                         |

--- a/docs/evm_compatibility/json_rpc_api_methods.md
+++ b/docs/evm_compatibility/json_rpc_api_methods.md
@@ -63,7 +63,7 @@ Split this into standard ETH-supported methods // Not supported methods // AND a
 | 40  | [eth_getTransactionReceipt](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionrecepit)               | _Returns the receipt of a transaction by transaction hash_                                                                                                    | ![done](img/done.ico)              |
 
 Methods `eth_getTransactionByHash`,  `eth_getTransactionByBlockHashAndIndex`, `eth_getTransactionByBlockNumberAndIndex`, `eth_getBlockByHash` and `eth_getBlockByNumber` also return the `chainId` property in addition to the [specified](https://ethereum.org/en/developers/docs/apis/json-rpc) output.
-wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
+
 ## JSON-RPC methods according to the [Web3 Module API](https://openethereum.github.io/JSONRPC-web3-module)
 
 | Num | Method                                                                                       | Description                                                            | Status                         |

--- a/static/schemas/neon-api/v1/neon_emulate/request.json
+++ b/static/schemas/neon-api/v1/neon_emulate/request.json
@@ -15,7 +15,7 @@
     "id": {
       "type": "number",
       "examples": [
-        "OpEgqw7r98qwerqwehkjhwe8"
+        "1716308324042"
       ],
       "description": "End-user provided identifier for the request; returned with payload."
     },

--- a/static/schemas/neon-api/v1/neon_emulate/response.json
+++ b/static/schemas/neon-api/v1/neon_emulate/response.json
@@ -15,60 +15,51 @@
       "description": "End-user provided identifier for the request."
     },
     "result": {
-      "accounts": [
-        {
-          "account": "2iBArBKoWNTG2gJ8KfEMtGv63CFPfTnwfsvarBncLtRX",
-          "additional_resize_steps": 0,
-          "address": "0xa59cd271578da4931c093f7611488b0a1a4bd198",
-          "new": false,
-          "size": 71,
-          "size_current": 71,
-          "writable": true
-        },
-        {
-          "account": "7Q8xmg4pHEfxTdwrKKpho6WfX6eFYRsDUuABsnk9iMB8",
-          "additional_resize_steps": 0,
-          "address": "0x549b5cb2d324f901aed6938a3838fb9b10898441",
-          "new": false,
-          "size": 11427,
-          "size_current": 11427,
-          "writable": false
-        },
-        {
-          "account": "AJthh52LdmRpif8HevQUF5TN4tuLCqGMQbm1rDuSkpzZ",
-          "additional_resize_steps": 0,
-          "address": "0x6dcdd1620ce77b595e6490701416f6dbf20d2f67",
-          "new": false,
-          "size": 10550,
-          "size_current": 10550,
-          "writable": false
-        }
-      ],
-      "solana_accounts": [
-        {
-          "is_writable": false,
-          "pubkey": "AUmmih1fr3Spj6rd8LFYB1EhfyMV24NqusM8QbWAoBad"
-        },
-        {
-          "is_writable": false,
-          "pubkey": "CnvWtQMgWiG7KzYMTBYXwk8PB2YYxRzPAZBaPWhRkctJ"
-        },
-        {
-          "is_writable": false,
-          "pubkey": "HFVUvrCzh26DTFpxjGzSn8cHn2sCtZGJogk3YhmBmzQ4"
-        }
-      ],
-      "actions": [
-        {
-          "EvmIncrementNonce": {
-            "address": "0xa59cd271578da4931c093f7611488b0a1a4bd198"
-          }
-        }
-      ],
-      "exit_status": "revert",
-      "result": "08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002645524332303a207472616e7366657220616d6f756e7420657863656564732062616c616e63650000000000000000000000000000000000000000000000000000",
-      "steps_executed": 919,
-      "used_gas": 30000
+      "exitCode": "revert",
+      "externalSolanaCall": false,
+      "revertBeforeSolanaCall": true,
+      "revertAfterSolanaCall": false,
+      "result": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000007a45787465726e616c2063616c6c206661696c7320546f6b656e6b65675166655a79694e77414a624e62474b50465843577542766639537336323356513544413a204572726f722070726f63657373696e6720496e737472756374696f6e20303a20637573746f6d2070726f6772616d206572726f723a20307834000000000000",
+      "numEvmSteps": 441,
+      "gasUsed": 25000,
+      "numIterations": 3,
+      "solanaAccounts": [
+       {
+          "pubkey": "7pjifx9FL83gidWbR3KvwwRJb1ThJe3NabhBG3VtjdC3",
+          "isWritable": true,
+          "isLegacy": false
+       },
+       {
+          "pubkey": "6gANWp6ZbZpdpt5GhBoCopNAJv1iTnA9kf7L7VRj2ivj",
+          "isWritable": false,
+          "isLegacy": false
+       },
+       {
+          "pubkey": "4dWQAaevdp89Jqr5GQV8KTZkG7Un9kvj7QY8fUnJHCgc",
+          "isWritable": true,
+          "isLegacy": false
+       },
+       {
+          "pubkey": "EMDBr8bmj7FjSWEmsKeBZZfikuFXhWTJKhQSj41NFLaB",
+          "isWritable": true,
+          "isLegacy": false
+       },
+       {
+          "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "isWritable": false,
+          "isLegacy": false
+       },
+       {
+          "pubkey": "DR6toPZGbKRdgfQ7krDRrdbX8NDatuttteuXtAcFm4mF",
+          "isWritable": false,
+          "isLegacy": false
+       },
+       {
+          "pubkey": "9WY2FENzKGCDQgoi8dXxJrvAqPqoWpKmnXvu7KgADSeb",
+          "isWritable": false,
+          "isLegacy": false
+       }
+      ]
     }
   },
   "required": [

--- a/static/schemas/neon-api/v1/neon_getEvmParams/request.json
+++ b/static/schemas/neon-api/v1/neon_getEvmParams/request.json
@@ -14,13 +14,13 @@
     },
     "method": {
       "type": "string",
-      "const": "nneon_getEvmParams",
+      "const": "neon_getEvmParams",
       "description": "The method name."
     },
     "id": {
       "type": "number",
       "examples": [
-        "OpEgqw7r98qwerqwehkjhwe8"
+        "1712927726192"
       ],
       "description": "End-user provided identifier for the request; returned with payload."
     }

--- a/static/schemas/neon-api/v1/neon_getEvmParams/response.json
+++ b/static/schemas/neon-api/v1/neon_getEvmParams/response.json
@@ -20,30 +20,16 @@
       "description": "End-user provided identifier for the request."
     },
     "result": {
-        "NEON_ACCOUNT_SEED_VERSION": "3",
-        "NEON_ADDITIONAL_FEE": "0",
-        "NEON_CHAIN_ID": "245022926",
-        "NEON_COMPUTE_BUDGET_HEAP_FRAME": "262144",
-        "NEON_COMPUTE_BUDGET_UNITS": "500000",
-        "NEON_EVM_STEPS_LAST_ITERATION_MAX": "1",
-        "NEON_EVM_STEPS_MIN": "500",
-        "NEON_GAS_LIMIT_MULTIPLIER_NO_CHAINID": "1000",
-        "NEON_HOLDER_MSG_SIZE": "950",
-        "NEON_OPERATOR_PRIORITY_SLOTS": "16",
-        "NEON_PAYMENT_TO_DEPOSIT": "5000",
-        "NEON_PAYMENT_TO_TREASURE": "5000",
-        "NEON_PKG_VERSION": "0.15.13",
-        "NEON_POOL_COUNT": "128",
-        "NEON_POOL_SEED": "treasury_pool",
-        "NEON_REQUEST_UNITS_ADDITIONAL_FEE": "0",
-        "NEON_REVISION": "9a4bbf29359e752336c0a1ff5fcb03e3ad303b7a",
-        "NEON_STATUS_NAME": "WORK",
-        "NEON_STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT": "64",
-        "NEON_TOKEN_MINT": "89dre8rZjLNft7HoupGiyxu3MNftR577ZYu8bHe2kK7g",
-        "NEON_TOKEN_MINT_DECIMALS": "9",
-        "NEON_TREASURY_POOL_COUNT": "128",
-        "NEON_TREASURY_POOL_SEED": "treasury_pool",
-        "NEON_EVM_ID": "eeLSJgWzzxrqKv1UxtRVVH8FX3qCQWUs9QuAjJpETGU"
+        "neonAccountSeedVersion": "3",
+        "neonMaxEvmStepsInLastIteration": "1",
+        "neonMinEvmStepsInIteration": "500",
+        "neonGasLimitMultiplierWithoutChainId": "1000",
+        "neonHolderMessageSize": "950",
+        "neonPaymentToTreasury": "5000",
+        "neonStorageEntriesInContractAccount": "64",
+        "neonTreasuryPoolCount": "128",
+        "neonTreasuryPoolSeed": "treasury_pool",
+        "neonEvmProgramId": "53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io"
     }
 }
 }


### PR DESCRIPTION
[Neon Proxy API](https://docs.neonevm.org/docs/api/neon-api)
- Changed names and parameters of some methods
- Changed request and response examples
- Fixed some typos and links

[JSON-RPC API Methods](https://docs.neonevm.org/docs/evm_compatibility/json_rpc_api_methods)
- Added list of methods with chainId 

It is good to have the changes published just after MainNet update.