### PR TITLE
TBA-195  exclude api3 reference from neon evm docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -196,7 +196,8 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
-          { from: '/docs', to: '/docs/quick_start' }
+          { from: '/docs', to: '/docs/quick_start' },
+          { from: '/docs/developing/integrate/oracles/integrating_api3', to: '/docs/quick_start' }
         ]
       }
     ]

--- a/linkcheck.config.json
+++ b/linkcheck.config.json
@@ -46,6 +46,9 @@
       "pattern": "^https://thegraph.neonevm.org/index-node/graphql"
     },
     {
+      "pattern": "^https://solscan.io/"
+    },
+    {
       "pattern": "^https://phantom.app"
     }
   ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -80,7 +80,7 @@ const sidebars = {
         'developing/integrate/wallets/integrating_web3auth',
         'developing/integrate/oracles/integrating_chainlink',
         'developing/integrate/oracles/integrating_pyth',
-        'developing/integrate/oracles/integrating_api3',
+        // 'developing/integrate/oracles/integrating_api3', integrating_api3 item is blocked (detalis are in TBA-195)
         'developing/integrate/middleware/the-graph',
         'developing/integrate/indexer/flair',
         'developing/integrate/indexer/envio',


### PR DESCRIPTION
Page about [API3](https://neonevm.org/docs/developing/integrate/oracles/integrating_api3) is blocked:
- hiden in the side barr menu
- rederection to the main page in case of direct link 