### PR TITLE
TBA-197 Remove PRX_GAS_PRICE_SLIPPAGE

### DIFF
--- a/docs/operating/transaction-gas.mdx
+++ b/docs/operating/transaction-gas.mdx
@@ -42,7 +42,7 @@ The Neon Proxy obtains the current prices of SOL and NEON tokens from the [pyth.
 
 > This ensures that the Neon Operator receives enough NEON to cover the transaction cost in SOL.
 
-The Neon Operator configures the value of `PRX_OPERATOR_FEE`, where 1.0 represents 100% of the potential fee extraction. The value of this parameter is currently set to **2.5**.
+The Neon Operator configures the value of `PRX_OPERATOR_FEE`, where 1.0 represents 100% of the potential fee extraction. The value of this parameter is currently set to **1**.
 
 <!-- Parameter `PRX_GAS_PRICE_SLIPPAGE` provides a buffer against transactions getting stuck in the mempool if there is volatility in prices of $SOL and $NEON. The value of this parameter is currently set to **0.25**.-->
 

--- a/docs/operating/transaction-gas.mdx
+++ b/docs/operating/transaction-gas.mdx
@@ -44,7 +44,7 @@ The Neon Proxy obtains the current prices of SOL and NEON tokens from the [pyth.
 
 The Neon Operator configures the value of `PRX_OPERATOR_FEE`, where 1.0 represents 100% of the potential fee extraction. The value of this parameter is currently set to **2.5**.
 
-Parameter `PRX_GAS_PRICE_SLIPPAGE` provides a buffer against transactions getting stuck in the mempool if there is volatility in prices of $SOL and $NEON. The value of this parameter is currently set to **0.25**.
+<!-- Parameter `PRX_GAS_PRICE_SLIPPAGE` provides a buffer against transactions getting stuck in the mempool if there is volatility in prices of $SOL and $NEON. The value of this parameter is currently set to **0.25**.-->
 
 For example:
 

--- a/docs/single-source-snippets/_gas_price_calc.mdx
+++ b/docs/single-source-snippets/_gas_price_calc.mdx
@@ -4,8 +4,7 @@
 | Neon                     | 1.5              | $                       |                   |
 | Ratio                    |                  | SOL:NEON                | 83.3333           |
 | Galan ratio              |                  | Ratio \*10<sup>-9</sup> | 0.0000000833333   |
-| Operator fee ratio       | 2.5              |                         |                   |
-<!--| Proxy Gas Price Slippage | 0.25             |                         |                   |-->
-| Adjustor                 |                  | 1+fee<!--+slippage-->   | <!--3.75-->3.5    |
-| **Gas price**            | **0.0000003125** | NEON                    | Gas price formula |
-|                          |<!--312.5-->**312.25**| Galan               |                   |
+| Operator fee ratio       | 1                |                         |                   |
+| Adjustor                 |                  | 1+fee                   | 2                 |
+| **Gas price**            | **0.0000001666666** | NEON                    | Gas price formula |
+|                          |**166.6**         | Galan                   |                   |

--- a/docs/single-source-snippets/_gas_price_calc.mdx
+++ b/docs/single-source-snippets/_gas_price_calc.mdx
@@ -5,7 +5,7 @@
 | Ratio                    |                  | SOL:NEON                | 83.3333           |
 | Galan ratio              |                  | Ratio \*10<sup>-9</sup> | 0.0000000833333   |
 | Operator fee ratio       | 2.5              |                         |                   |
-| Proxy Gas Price Slippage | 0.25             |                         |                   |
-| Adjustor                 |                  | 1+fee+slippage          | 3.75              |
+<!--| Proxy Gas Price Slippage | 0.25             |                         |                   |-->
+| Adjustor                 |                  | 1+fee<!--+slippage-->   | <!--3.75-->3.5    |
 | **Gas price**            | **0.0000003125** | NEON                    | Gas price formula |
-|                          | **312.5**        | Galan                   |
+|                          |<!--312.5-->**312.25**| Galan               |                   |

--- a/docs/single-source-snippets/_price_formula.mdx
+++ b/docs/single-source-snippets/_price_formula.mdx
@@ -1,8 +1,8 @@
-> Gas price = $SOL / $NEON(* 10<sup>-9</sup> NEON) * (1 + `PRX_OPERATOR_FEE` + `PRX_GAS_PRICE_SLIPPAGE`)
+> Gas price = $SOL / $NEON(* 10<sup>-9</sup> NEON) * (1 + `PRX_OPERATOR_FEE`)
 
 which can also be represented as:
 
-> Gas price = SOL-to-NEON-rate in Galan * (1 + `PRX_OPERATOR_FEE` + `PRX_GAS_PRICE_SLIPPAGE`)
+> Gas price = SOL-to-NEON-rate in Galan * (1 + `PRX_OPERATOR_FEE`)
 
 
 


### PR DESCRIPTION
PRX_GAS_PRICE_SLIPPAGE removed in formulas and the example table 
PRX_OPERATOR_FEE == 1 in the formula description and the example table 